### PR TITLE
[minor] added typedef to overload base type

### DIFF
--- a/autodiff/forward/dual/dual.hpp
+++ b/autodiff/forward/dual/dual.hpp
@@ -1495,11 +1495,15 @@ using detail::eval;
 using detail::Dual;
 using detail::HigherOrderDual;
 
-using dual0th = HigherOrderDual<0, double>;
-using dual1st = HigherOrderDual<1, double>;
-using dual2nd = HigherOrderDual<2, double>;
-using dual3rd = HigherOrderDual<3, double>;
-using dual4th = HigherOrderDual<4, double>;
+#if not defined(USERTYPE)
+typedef double Number_t;
+#endif
+
+using dual0th = HigherOrderDual<0, Number_t>;
+using dual1st = HigherOrderDual<1, Number_t>;
+using dual2nd = HigherOrderDual<2, Number_t>;
+using dual3rd = HigherOrderDual<3, Number_t>;
+using dual4th = HigherOrderDual<4, Number_t>;
 
 using dual = dual1st;
 


### PR DESCRIPTION
This is a minor extension to allow overloading the base numeric type used.

Trivial example would be to use e.g. `float` instead of `double`. But the true purpose would of course be to go with `std::valarray<double>` or `std::valarray<float>` to vectorise as well as differentiate scalar code automatically. I haven't worked out how to typedef them properly yet. If you have an idea of how to do this I'd much appreciate it :)

The trivial case is this one, but I assume that some people might be interested in 16 bit floating point ones as well or why not even GMP..

```
#include <iostream>

using namespace std;

#include <Eigen/Core>
using namespace Eigen;

typedef float Number_t;
#define USERTYPE

#include <autodiff/forward/dual.hpp>
#include <autodiff/forward/dual/eigen.hpp>

using namespace autodiff;

dual2nd fun(const VectorXdual2nd& u) {
    return sin(2.*u[0]+exp(u[1]));
}

int main() {

    VectorXdual2nd x(2);
    dual2nd fx;
    VectorXdual dfx;

    x[0] = 1.;
    x[1] = 1.;

    MatrixXf ddfx = hessian(fun, wrt(x), at(x), fx, dfx);
    
    cout << "f(x) = " << fx << endl;
    cout << "df(x) =  " << endl << dfx << endl;
    cout << "ddf(x) = " << endl << ddfx << endl;

    return 0;
}

```
